### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/action-check.yml
+++ b/.github/workflows/action-check.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.1.1
         with:
           token: ${{ secrets.WORKFLOW_SECRET }}
       - name: Run GitHub Actions Version Updater

--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -26,13 +26,13 @@ jobs:
         os: [windows,ubuntu,macos]
     runs-on: ${{ matrix.os }}-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.1.1
       - name: Use Node.js 20.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v4.0.2
         with:
           node-version: "20"
       - name: Cache NPM dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4.0.2
         with:
           path: ./electron-static/node_modules
           key: ${{ runner.os }}-npm-app-cache
@@ -51,7 +51,7 @@ jobs:
          cd electron-static
          7z a -tzip genish-impact-${{ runner.os }}-x64.zip ./genish-impact-*
       - name: Upload (${{ runner.os }})
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.1
         with:
           name: genish-impact-${{ runner.os }}
           path: electron-static/genish-impact-${{ runner.os }}-x64.zip

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -17,13 +17,13 @@ jobs:
   Build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.1.1
       - name: Use Node.js 20.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v4.0.2
         with:
           node-version: "20"
       - name: Cache NPM dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4.0.2
         with:
           path: ./Genshin-Impact-Wish-Simulator/node_modules
           key: ${{ runner.OS }}-npm-frontend-cache
@@ -41,12 +41,12 @@ jobs:
         run: |
           docker build -t maizig/ysdm:latest .
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3.1.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Push to DockerHub
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5.3.0
         with:
           context: .
           push: true

--- a/.github/workflows/page.yml
+++ b/.github/workflows/page.yml
@@ -18,13 +18,13 @@ jobs:
   Build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.1.1
       - name: Use Node.js 20.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v4.0.2
         with:
           node-version: "20"
       - name: Cache NPM dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4.0.2
         with:
           path: ./Genshin-Impact-Wish-Simulator/node_modules
           key: ${{ runner.OS }}-npm-frontend-cache
@@ -43,7 +43,7 @@ jobs:
          cd Genshin-Impact-Wish-Simulator
          7z a -tzip frontend.zip ./.vercel/output/static
       - name: Upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.1
         with:
           name: frontend
           path: Genshin-Impact-Wish-Simulator/frontend.zip
@@ -58,9 +58,9 @@ jobs:
          git config --global user.name github-actions[bot]
          git config --global user.email 41898282+github-actions[bot]@users.noreply.github.com
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
       - name: Download Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4.1.4
         with:
             name: frontend
       - name: Remove old

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,11 +16,11 @@ jobs:
     needs: app
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.1.1
       - name: Download Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4.1.4
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2.0.4
         with:
             files: ./**/genish-impact*.*
             body_path: ./CHANGELOG.md

--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -13,7 +13,7 @@ jobs:
             os: [windows,ubuntu,macos]
         runs-on: ${{ matrix.os }}-latest
         steps:
-          - uses: actions/checkout@v4
+          - uses: actions/checkout@v4.1.1
           - name: install Rust stable
             uses: dtolnay/rust-toolchain@stable
           - name: install dependencies (ubuntu only)
@@ -22,18 +22,18 @@ jobs:
               sudo apt-get update
               sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev libappindicator3-dev librsvg2-dev patchelf
           - name: Use Node.js 20.x
-            uses: actions/setup-node@v4
+            uses: actions/setup-node@v4.0.2
             with:
               node-version: "20"
           - name: Cache NPM dependencies
-            uses: actions/cache@v3
+            uses: actions/cache@v4.0.2
             with:
               path: ./Genshin-Impact-Wish-Simulator/node_modules
               key: ${{ runner.OS }}-npm-frontend-cache
               restore-keys: |
                 ${{ runner.OS }}-npm-frontend-cache
           - name: Cache Rust
-            uses: Swatinem/rust-cache@v2
+            uses: Swatinem/rust-cache@v2.7.3
             with:
               prefix-key: "Cache-${{ runner.os }}"
               workspaces: "Genshin-Impact-Wish-Simulator/src-tauri"
@@ -48,25 +48,25 @@ jobs:
              yarn run tauri build
           - name: Upload (Windows)
             if: runner.os == 'windows'
-            uses: actions/upload-artifact@v3
+            uses: actions/upload-artifact@v4.3.1
             with:
               name: genish-impact-Tauri-${{ runner.os }}
               path: Genshin-Impact-Wish-Simulator/src-tauri/target/release/bundle/
           - name: Upload Appimage (Linux)
             if: runner.os == 'Linux'
-            uses: actions/upload-artifact@v3
+            uses: actions/upload-artifact@v4.3.1
             with:
               name: genish-impact-Tauri-${{ runner.os }}-appimage
               path: Genshin-Impact-Wish-Simulator/src-tauri/target/release/bundle/appimage/genish-impact_*.AppImage
           - name: Upload deb (Linux)
             if: runner.os == 'Linux'
-            uses: actions/upload-artifact@v3
+            uses: actions/upload-artifact@v4.3.1
             with:
               name: genish-impact-Tauri-${{ runner.os }}-deb
               path: Genshin-Impact-Wish-Simulator/src-tauri/target/release/bundle/deb/genish-impact_*.deb
           - name: Upload dmg (Macos)
             if: runner.os == 'macos'
-            uses: actions/upload-artifact@v3
+            uses: actions/upload-artifact@v4.3.1
             with:
               name: genish-impact-Tauri-${{ runner.os }}-dmg
               path: Genshin-Impact-Wish-Simulator/src-tauri/target/release/bundle/dmg/*.dmg


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v4.0.2](https://github.com/actions/cache/releases/tag/v4.0.2)** on 2024-03-19T15:55:41Z
* **[actions/download-artifact](https://github.com/actions/download-artifact)** published a new release **[v4.1.4](https://github.com/actions/download-artifact/releases/tag/v4.1.4)** on 2024-03-01T18:28:41Z
* **[docker/login-action](https://github.com/docker/login-action)** published a new release **[v3.1.0](https://github.com/docker/login-action/releases/tag/v3.1.0)** on 2024-03-13T15:11:17Z
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v5.3.0](https://github.com/docker/build-push-action/releases/tag/v5.3.0)** on 2024-03-14T08:32:47Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.1](https://github.com/actions/checkout/releases/tag/v4.1.1)** on 2023-10-17T15:53:17Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v4.3.1](https://github.com/actions/upload-artifact/releases/tag/v4.3.1)** on 2024-02-05T21:40:25Z
* **[Swatinem/rust-cache](https://github.com/Swatinem/rust-cache)** published a new release **[v2.7.3](https://github.com/Swatinem/rust-cache/releases/tag/v2.7.3)** on 2024-01-14T08:32:29Z
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v4.0.2](https://github.com/actions/setup-node/releases/tag/v4.0.2)** on 2024-02-07T04:51:19Z
* **[softprops/action-gh-release](https://github.com/softprops/action-gh-release)** published a new release **[v2.0.4](https://github.com/softprops/action-gh-release/releases/tag/v2.0.4)** on 2024-03-12T16:27:56Z
